### PR TITLE
Fix: Correctly build React app for GitHub Pages deployment


### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Replace with your desired Node.js version
+      - name: Install dependencies and build
+        run: |
+          cd react-audio-player
+          npm install
+          npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./
+          path: react-audio-player/build # Upload the build directory
 
   deploy:
     needs: build


### PR DESCRIPTION
The previous deployment workflow was attempting to deploy the raw source code without a build step.

This change updates the `.github/workflows/deploy.yml` file to:
- Set up Node.js.
- Install dependencies and build the React application within the `react-audio-player` directory.
- Upload the `react-audio-player/build` directory as the artifact for GitHub Pages deployment.

This ensures that the built application is deployed, resolving the deployment failures.