### PR TITLE
Fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/react-audio-player/package.json
+++ b/react-audio-player/package.json
@@ -2,6 +2,7 @@
   "name": "react-audio-player",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://kenoir.github.io/the_fresh_prince",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
Adds the `homepage` field to `react-audio-player/package.json`. This ensures that Create React App generates correct relative paths for static assets when the application is deployed to a subdirectory on GitHub Pages (e.g., `https://username.github.io/repository-name/`).

This resolves 404 errors for CSS, JS, manifest.json, and other assets that were previously being requested from the root path instead of the deployment subdirectory.