### PR TITLE
Fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/react-audio-player/package.json
+++ b/react-audio-player/package.json
@@ -2,7 +2,7 @@
   "name": "react-audio-player",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://kenoir.github.io/the_fresh_prince",
+  "homepage": "https://kenoir.github.io/react-audio-player",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/react-audio-player/src/App.js
+++ b/react-audio-player/src/App.js
@@ -11,7 +11,7 @@ function App() {
 
   // Fetch Lyric Data
   useEffect(() => {
-    fetch('/belair.json')
+    fetch(`${process.env.PUBLIC_URL}/belair.json`)
       .then(response => response.json())
       .then(data => {
         setLyricsData(data.lines);
@@ -152,10 +152,10 @@ function App() {
     <>
       <header>
         <h1>the fresh prince</h1>
-        <p><a href="https://kenoir.github.io/the_fresh_prince/">https://kenoir.github.io/the_fresh_prince/</a></p>
+        <p><a href="https://kenoir.github.io/react-audio-player/">https://kenoir.github.io/react-audio-player/</a></p>
       </header>
 
-      <audio ref={audioRef} id="track" src="/audio/belair.mp3" muted>
+      <audio ref={audioRef} id="track" src={`${process.env.PUBLIC_URL}/audio/belair.mp3`} muted>
         <p>Your browser sucks and you should feel bad.</p>
       </audio>
 


### PR DESCRIPTION
Updates the application to correctly load assets when deployed to GitHub Pages.

Changes made:
- Modified `homepage` in `package.json` to `https://kenoir.github.io/react-audio-player` to align with the standard GitHub Pages project URL structure.
- Updated asset paths in `App.js` (for `belair.json` and `audio/belair.mp3`) to use `process.env.PUBLIC_URL`. This ensures they are resolved correctly relative to the `homepage` value.
- Updated the displayed link in `App.js` to point to the correct deployment URL.

These changes address the 404 errors for `belair.json` and `audio/belair.mp3` by ensuring all paths are correctly prefixed for the GitHub Pages environment.